### PR TITLE
Added Custom cachePath support

### DIFF
--- a/core/Bliss/src/App/Container.php
+++ b/core/Bliss/src/App/Container.php
@@ -72,12 +72,13 @@ class Container extends \Bliss\Component
 	 * 
 	 * @param string $name The name of the application
 	 */
-	public function __construct($name, $rootPath) 
+	public function __construct($name, $rootPath, $cachePath="files") 
 	{
 		ob_start();
 		
 		$this->name = $name;
 		$this->rootPath = $rootPath;
+		$this->cachePath = $cachePath;
 		$this->autoloader = new AutoLoader();
 		$this->moduleRegistry = new ModuleRegistry($this);
 		
@@ -94,9 +95,32 @@ class Container extends \Bliss\Component
 	 */
 	public function resolvePath($partial = null)
 	{
-		return $this->rootPath ."/". $partial;
+		//Detect if using gs:// for google app engine
+		if (strpos($partial, "://") !== false || strpos($partial, ":\\") !== false) {
+			return $this->cachePath ."/" . $partial;
+		} else {
+			return $this->rootPath ."/".$ this->cachePath . "/" . $partial;
+		}
 	}
-	
+
+	/**
+     * Sets the location of the cache
+     * 
+     * 
+     */
+   	public function setCachePath($path) {
+   		$this->cachePath = $path;
+	}
+
+    /**
+     * Gets the location of the cache
+     * 
+     * 
+     */
+    public function getCachePath() {
+        return $this->cachePath;
+    }
+
 	/**
 	 * Set the name of the application
 	 * 

--- a/core/Response/src/Module.php
+++ b/core/Response/src/Module.php
@@ -228,7 +228,7 @@ class Module extends \Bliss\Module\AbstractModule implements Format\ProviderInte
 			$this->cacheStorage = $storage;
 		}
 		if (!isset($this->cacheStorage)) {
-			$this->cacheStorage = new FileStorage($this->app->resolvePath("files/response"));
+			$this->cacheStorage = new FileStorage($this->app->resolvePath("response"));
 		}
 		return $this->cacheStorage;
 	}

--- a/development/Tests/src/Controller/RunnerController.php
+++ b/development/Tests/src/Controller/RunnerController.php
@@ -9,7 +9,7 @@ class RunnerController extends \Bliss\Controller\AbstractController
 	
 	public function init()
 	{
-		$this->configPath = $this->app->resolvePath("files/tests/config.xml");
+		$this->configPath = $this->app->resolvePath("tests/config.xml");
 		
 		$dir = dirname($this->configPath);
 		if (!is_dir($dir)) {

--- a/web-app.php
+++ b/web-app.php
@@ -24,9 +24,9 @@ class BlissWebApp extends \Bliss\App\Container
 {
 	private $startTime;
 	
-	public function __construct($name, $rootPath) 
+	public function __construct($name, $rootPath,$cachePath ="files") 
 	{
-		parent::__construct($name, $rootPath);
+		parent::__construct($name, $rootPath,$cachePath);
 		
 		$this->startTime = microtime(true);
 		
@@ -37,7 +37,7 @@ class BlissWebApp extends \Bliss\App\Container
 	 * @param string $rootPath
 	 * @return BlissWebApp
 	 */
-	public static function create($name, $rootPath, $environment = self::ENV_PRODUCTION)
+	public static function create($name, $rootPath, $environment = self::ENV_PRODUCTION,$cachePath = "files")
 	{
 		date_default_timezone_set("UTC");
 		error_reporting(-1);
@@ -49,7 +49,7 @@ class BlissWebApp extends \Bliss\App\Container
 		}
 		
 		// Create the application container
-		$instance = new self($name, $rootPath);
+		$instance = new self($name, $rootPath,$cachePath);
 		$instance->environment($environment);
 		$instance->autoloader()->registerNamespace("Bliss", __DIR__ ."/core/Bliss/src");
 		$instance->moduleRegistry()->registerModulesDirectory(__DIR__ ."/core");

--- a/web/Assets/src/Controller/AssetController.php
+++ b/web/Assets/src/Controller/AssetController.php
@@ -19,7 +19,7 @@ class AssetController extends \Bliss\Controller\AbstractController
 			);
 			$sourcePath = $module->resolvePath("assets/". $sourceName);
 			$filename = $this->module->resolvePath(
-				sprintf("files/compiled/%s/%s",
+				sprintf("compiled/%s/%s",
 					$moduleName,
 					$sourceName
 				)
@@ -50,7 +50,7 @@ class AssetController extends \Bliss\Controller\AbstractController
 	public function renderAllAction(\Request\Module $request, \Response\Module $response)
 	{
 		$formatName = $request->getFormat();
-		$filename = $this->app->resolvePath("files/assets/compiled/all.{$formatName}");
+		$filename = $this->app->resolvePath("assets/compiled/all.{$formatName}");
 		$compiler = $this->module->compiler();
 		
 		if ($compiler->isEnabled()) {


### PR DESCRIPTION
Allows you to specify an optional "cachePath" which can be used to support Google app engine datastores.

eg

$app = BlissWebApp::create("My Site", $root, $env,'gs://myallwebcache/files');
